### PR TITLE
Add hook for fetching advocates

### DIFF
--- a/DISCUSSION.md
+++ b/DISCUSSION.md
@@ -9,7 +9,7 @@
 
 ### Improvement ideas
 
-- [] Set up service or custom hooks to improve data fetching structure
+- [x] Set up service or custom hooks to improve data fetching structure
 - [x] Filter using the database instead of the front end
 - [] Add better error logging. Replace console.errors with Pino or other logging library
 - [] Add testing framework

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "next": "^14.2.19",
         "postgres": "^3.4.4",
         "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react-dom": "^18.3.1",
+        "swr": "^2.3.3"
       },
       "devDependencies": {
         "@types/node": "^20.14.12",
@@ -2057,6 +2058,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/didyoumean": {
@@ -5363,6 +5373,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/swr": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.3.3.tgz",
+      "integrity": "sha512-dshNvs3ExOqtZ6kJBaAsabhPdHyeY4P2cKwRCniDVifBMoG/SVI7tfLWqPXriVspf2Rg4tPzXJTnwaihIeFw2A==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/tailwindcss": {
       "version": "3.4.16",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.16.tgz",
@@ -5622,6 +5645,15 @@
       "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
+      "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "next": "^14.2.19",
     "postgres": "^3.4.4",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "swr": "^2.3.3"
   },
   "devDependencies": {
     "@types/node": "^20.14.12",

--- a/src/app/hooks/useAdvocates.ts
+++ b/src/app/hooks/useAdvocates.ts
@@ -1,0 +1,22 @@
+import useSWR from "swr";
+
+const fetcher = (url: string) => fetch(url).then((res) => res.json());
+
+type Advocate = {
+    id: string;
+    firstName: string;
+    lastName: string;
+    city: string;
+    degree: string;
+    specialties: string[];
+    yearsOfExperience: number;
+    phoneNumber: number;
+    createdAt: string;
+  };
+
+export const useAdvocates = (searchTerm: string | null) => {
+    const query = searchTerm ? `?search=${encodeURIComponent(searchTerm)}` : "";
+    const { data, error, isLoading } = useSWR<{data: Advocate[]}>(`/api/advocates${query}`, fetcher);
+    console.log('data', data)
+    return { advocates: data?.data || [], advocatesError: error, advocatesAreLoading: isLoading };
+  };

--- a/src/app/hooks/useAdvocates.ts
+++ b/src/app/hooks/useAdvocates.ts
@@ -17,6 +17,5 @@ type Advocate = {
 export const useAdvocates = (searchTerm: string | null) => {
     const query = searchTerm ? `?search=${encodeURIComponent(searchTerm)}` : "";
     const { data, error, isLoading } = useSWR<{data: Advocate[]}>(`/api/advocates${query}`, fetcher);
-    console.log('data', data)
     return { advocates: data?.data || [], advocatesError: error, advocatesAreLoading: isLoading };
   };

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,31 +1,21 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
+import { useAdvocates } from "./hooks/useAdvocates";
 
 export default function Home() {
-  const [advocates, setAdvocates] = useState([]);
   const [searchTerm, setSearchTerm] = useState<string>("");
+  const [submittedSearch, setSubmittedSearch] = useState<string | null>(null);
 
-  useEffect(() => {
-    fetch(`/api/advocates`).then((response) => {
-      response.json().then((jsonResponse) => {
-        setAdvocates(jsonResponse.data);
-      });
-    });
-  }, [searchTerm]);
+  const { advocates, advocatesAreLoading, advocatesError } =
+    useAdvocates(submittedSearch);
 
   const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setSearchTerm(e.target.value);
   };
 
   const onClick = () => {
-    fetch(`/api/advocates?search=${encodeURIComponent(searchTerm)}`).then(
-      (response) => {
-        response.json().then((jsonResponse) => {
-          setAdvocates(jsonResponse.data);
-        });
-      }
-    );
+    setSubmittedSearch(searchTerm);
   };
 
   return (


### PR DESCRIPTION
What
- Add in a useAdvocates hook instead of using fetch in the component itself
- Pulled in SWR because it is recommended by Next
- Added in Advocate type to start adhering to TS

Why
- Prevents duplication of code in this component and as more components are built out.
- Makes code easier to read
- I think this is a better structure for the application.  Good to start now instead of having to refactor everything later